### PR TITLE
Fix hooks for tmux 3.2

### DIFF
--- a/unified-titles.tmux
+++ b/unified-titles.tmux
@@ -102,6 +102,6 @@ main() {
 main
 
 # Update string on attach and detatch
-tmux set-hook -g after-client-attached "run \"$CURRENT_DIR/unified-titles.tmux\""
 tmux set-hook -g alert-bell "run \"$CURRENT_DIR/scripts/set_tmux_title.sh bell\""
-tmux set-hook -g after-client-detached "run \"echo -ne \\\"\e]0;$HOSTNAME\a\\\"\""
+tmux set-hook -g client-attached "run \"$CURRENT_DIR/unified-titles.tmux\""
+tmux set-hook -g client-detached "run \"echo -ne \\\"\e]0;$HOSTNAME\a\\\"\""


### PR DESCRIPTION
This ensures that this plugin works with tmux 3.2+ without throwing tpm errors when loaded.

The `after-client-attached` and `after-client-detached` hooks were renamed to `client-attached` and `client-detached`. 