### PR TITLE
Fix shebangs

### DIFF
--- a/scripts/get_hoststring.py
+++ b/scripts/get_hoststring.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Get hostname, convert using $tzvt_host_dict if set.

--- a/scripts/set_tmux_title.sh
+++ b/scripts/set_tmux_title.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Actually set the tmux terminal title, not the window title
 # Inherits all variables from calling script, used by ZSH and
 # tmux plugin


### PR DESCRIPTION
This fixes the shebangs so that they use `#!/usr/bin/env` instead of assuming 
the paths to bash/python

On NixOS, both of these scripts do not work because `/bin/bash` and 
`/usr/bin/python` do not exist.
